### PR TITLE
Add PulseAudio and ALSA support for working Linux audio.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ ENDFLAGS := -fPIC
 ifeq ($(OS),Windows_NT)
 LDFLAGS := $(LDFLAGS) -mwindows
 ENDFLAGS := -static -lole32 -lstdc++
+else
+LDFLAGS := $(LDFLAGS) -lasound -lpulse # Add alsa and pulseaudio libraries for linux audio
 endif
 
 SRC_DIRS  := src src/decomp src/decomp/engine src/decomp/include/PR src/decomp/game src/decomp/pc src/decomp/pc/audio src/decomp/mario src/decomp/tools src/decomp/audio src/decomp/model_luigi src/decomp/model_alex src/decomp/model_steve src/decomp/model_necoarc src/decomp/model_vibri

--- a/src/libsm64.c
+++ b/src/libsm64.c
@@ -38,6 +38,8 @@
 #include "fpsLimitHelper.h"
 #include "decomp/pc/audio/audio_null.h"
 #include "decomp/pc/audio/audio_wasapi.h"
+#include "decomp/pc/audio/audio_pulse.h"
+#include "decomp/pc/audio/audio_alsa.h"
 #include "decomp/audio/external.h"
 
 #include "decomp/audio/load_dat.h"


### PR DESCRIPTION
Nothing too crazy, just added the header files for pulse and alsa and modified the makefile to build with the -lasound and -lpulse flags when the OS is not Windows (I essentially lifted this from [sm64-port's](https://github.com/sm64-port/sm64-port) makefile). This is my first time working with C or make so let me know if anything doesn't stand up to scrutiny. I've only tested this on my laptop running Manjaro (5.15.28-1-MANJARO).