### PR TITLE
Fixed healing while underwater and crawling under a 1 gap block

### DIFF
--- a/src/decomp/engine/math_util.c
+++ b/src/decomp/engine/math_util.c
@@ -1858,9 +1858,9 @@ void mtxf_align_terrain_triangle(Mat4 mtx, Vec3f pos, s16 yaw, f32 radius) {
     point2[0] = pos[0] + radius * sins(yaw + 0xD555);
     point2[2] = pos[2] + radius * coss(yaw + 0xD555);
 
-    point0[1] = find_floor(point0[0], pos[1] + 150, point0[2], &sp74);
-    point1[1] = find_floor(point1[0], pos[1] + 150, point1[2], &sp74);
-    point2[1] = find_floor(point2[0], pos[1] + 150, point2[2], &sp74);
+    point0[1] = find_floor(point0[0], pos[1], point0[2], &sp74);
+    point1[1] = find_floor(point1[0], pos[1], point1[2], &sp74);
+    point2[1] = find_floor(point2[0], pos[1], point2[2], &sp74);
 
     if (point0[1] - pos[1] < minY) {
         point0[1] = pos[1];

--- a/src/decomp/game/mario.c
+++ b/src/decomp/game/mario.c
@@ -1480,7 +1480,7 @@ void update_mario_health(struct MarioState *m) {
                     // When Mario is near the water surface, recover health (unless in snow),
                     // when in snow terrains lose 3 health.
                     // If using the debug level select, do not lose any HP to water.
-                    if ((m->pos[1] >= (m->waterLevel - 140)) && !terrainIsSnow) {
+                    if ((m->pos[1] >= (m->waterLevel - 120)) && !terrainIsSnow) {
                         m->health += 0x1A;
                     } else if (!gDebugLevelSelect) {
                         m->health -= (terrainIsSnow ? 3 : 1);

--- a/src/decomp/game/mario_step.c
+++ b/src/decomp/game/mario_step.c
@@ -294,7 +294,7 @@ static s32 perform_ground_quarter_step(struct MarioState *m, Vec3f nextPos) {
         return GROUND_STEP_LEFT_GROUND;
     }
 
-    if (floorHeight + 160.0f >= ceilHeight) {
+    if (!(m->action & ACT_FLAG_SHORT_HITBOX) && floorHeight + 160.0f >= ceilHeight) {
         return GROUND_STEP_HIT_WALL_STOP_QSTEPS;
     }
 


### PR DESCRIPTION
Fixed some bugs with crawling under a 1 gap block and healing while underneath a block while submerged in water.